### PR TITLE
[Refactor] Cleanup in example

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -16,8 +16,8 @@
   },
   "homepage": "https://github.com/lochbrunner/react-flow-editor#readme",
   "devDependencies": {
-    "@types/lodash": "^4.14.182",
     "@types/react": "17.0.30",
+    "@types/react-dom": "^18.0.8",
     "@vitejs/plugin-react": "^1.3.2",
     "eslint": "^8.20.0",
     "typescript": "^4.0.3",
@@ -26,12 +26,8 @@
   },
   "dependencies": {
     "@kseniass/react-flow-editor": "file:../react-flow-editor/",
-    "lodash": "^4.17.21",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sass": "^1.53.0"
-  },
-  "resolutions": {
-    "@types/react": "15.6.19"
   }
 }

--- a/packages/examples/src/constants.tsx
+++ b/packages/examples/src/constants.tsx
@@ -1,4 +1,4 @@
-import { Node } from "@kseniass/react-flow-editor"
+import { Node, StyleConfig } from "@kseniass/react-flow-editor"
 
 export const DEFAULT_OUTPUT = {
   x: 145,
@@ -61,7 +61,7 @@ export const TIPS = `
   - Scroll mouse to zoom
 `
 
-export const STYLED_CONFIG = {
+export const STYLED_CONFIG: StyleConfig = {
   point: {
     width: 10,
     height: 10,
@@ -70,6 +70,7 @@ export const STYLED_CONFIG = {
     disconnectedBg: "#fafafa"
   },
   connector: {
+    width: 10,
     color: "#7d7d7d"
   }
 }

--- a/packages/examples/src/helpers.tsx
+++ b/packages/examples/src/helpers.tsx
@@ -6,13 +6,14 @@ import { DEFAULT_OUTPUT } from "./constants"
 export const computeSelectionZone = (
   zoomContainerRef: MutableRefObject<HTMLDivElement> | undefined,
   transformation: Transformation,
-  selectionZone: SelectionZone
+  selectionZone: SelectionZone | null
 ): Partial<DOMRect> => {
   const zoomContainerRect = zoomContainerRef?.current.getBoundingClientRect()
-  const left = zoomContainerRect?.left || 0 + selectionZone?.left * transformation.zoom || 0
-  const top = zoomContainerRect?.top || 0 + selectionZone?.top * transformation.zoom || 0
-  const right = zoomContainerRect?.left || 0 + selectionZone?.right * transformation.zoom || 0
-  const bottom = zoomContainerRect?.top || 0 + selectionZone?.bottom * transformation.zoom || 0
+
+  const left = (zoomContainerRect?.left || 0) + (selectionZone?.left || 0) * transformation.zoom || 0
+  const top = (zoomContainerRect?.top || 0) + (selectionZone?.top || 0) * transformation.zoom || 0
+  const right = (zoomContainerRect?.left || 0) + (selectionZone?.right || 0) * transformation.zoom || 0
+  const bottom = (zoomContainerRect?.top || 0) + (selectionZone?.bottom || 0) * transformation.zoom || 0
 
   return {
     left,

--- a/packages/examples/src/parts.tsx
+++ b/packages/examples/src/parts.tsx
@@ -1,17 +1,11 @@
 import * as React from "react"
-import { Node, NodeProps } from "@kseniass/react-flow-editor"
-import { SimpleNodeProps } from "./types"
-import { omit } from "lodash"
+import { Node } from "@kseniass/react-flow-editor"
 
 export const NodeAttributes: React.FC<{ nodes: Node[] }> = ({ nodes }) => (
   <div>
     <h2>Nodes attributes</h2>
     {nodes.map((node) => (
-      <pre key={node.id}> {JSON.stringify(omit(node, ["children"], null, 1)).replaceAll(/([{,])/g, "$1\n")}</pre>
+      <pre key={node.id}> {JSON.stringify(node).replaceAll(/([{,])/g, "$1\n")}</pre>
     ))}
   </div>
 )
-
-export const SimpleNode = (): React.FC<SimpleNodeProps> => (props: NodeProps) => <NodeExpanded {...props} />
-
-export const NodeExpanded: React.FC<SimpleNodeProps> = () => <div>Node</div>

--- a/packages/examples/src/simple.tsx
+++ b/packages/examples/src/simple.tsx
@@ -1,11 +1,11 @@
 import * as React from "react"
 import * as ReactDOM from "react-dom"
-import { Editor, Node, OnEditorRectsMountedProps, Transformation } from "@kseniass/react-flow-editor"
+import { Editor, Node, NodeProps, OnEditorRectsMountedProps, Transformation } from "@kseniass/react-flow-editor"
 import "./simple.scss"
 import { SelectionZone } from "./types"
 import { initialNodes, STYLED_CONFIG, TIPS } from "./constants"
 import { computeSelectionZone, nodeFactory } from "./helpers"
-import { NodeAttributes, SimpleNode } from "./parts"
+import { NodeAttributes } from "./parts"
 
 const App = () => {
   const [nodes, setNodes] = React.useState<Node[]>(initialNodes)
@@ -13,14 +13,7 @@ const App = () => {
   const [transformation, setTransformation] = React.useState<Transformation>({ dx: 0, dy: 0, zoom: 1 })
   const [editorRefs, setEditorRefs] = React.useState<OnEditorRectsMountedProps | null>(null)
 
-  const onSelectionZoneChanged = React.useCallback((val) => setSelectionZone(val), [])
-
-  const selectionZonePosition = React.useMemo(
-    () => computeSelectionZone(editorRefs?.zoomContainerRef, transformation, selectionZone),
-    [selectionZone, editorRefs]
-  )
-
-  const onEditorRectsMounted = React.useCallback((val) => setEditorRefs(val), [])
+  const selectionZonePosition = computeSelectionZone(editorRefs?.zoomContainerRef, transformation, selectionZone)
 
   return (
     <div className="editor-root">
@@ -30,20 +23,20 @@ const App = () => {
         <div className="button" onClick={() => setNodes((nodes) => [...nodes, nodeFactory()])}>
           Create new Node
         </div>
-        <div className="button" onClick={() => editorRefs.overview()}>
+        <div className="button" onClick={() => editorRefs?.overview()}>
           Overview
         </div>
         <NodeAttributes nodes={nodes} />
       </div>
       <div className="react-editor-container">
         <Editor
-          nodeRepresentation={SimpleNode()}
+          nodeRepresentation={(_: NodeProps) => <div>Node</div>}
           nodes={nodes}
           setNodes={setNodes}
           transformation={transformation}
           setTransformation={setTransformation}
-          onSelectionZoneChanged={onSelectionZoneChanged}
-          onEditorRectsMounted={onEditorRectsMounted}
+          onSelectionZoneChanged={setSelectionZone}
+          onEditorRectsMounted={setEditorRefs}
           importantNodeIds={[initialNodes[0].id]}
           styleConfig={STYLED_CONFIG}
         />

--- a/packages/examples/src/types.ts
+++ b/packages/examples/src/types.ts
@@ -1,10 +1,6 @@
-import { NodeProps } from "@kseniass/react-flow-editor"
-
 export type SelectionZone = {
   left: number
   top: number
   right: number
   bottom: number
 }
-
-export type SimpleNodeProps = NodeProps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,12 +31,10 @@ importers:
   packages/examples:
     specifiers:
       '@kseniass/react-flow-editor': file:../react-flow-editor/
-      '@types/lodash': ^4.14.182
       '@types/react': 17.0.30
       '@types/react-dom': ^18.0.8
       '@vitejs/plugin-react': ^1.3.2
       eslint: ^8.20.0
-      lodash: ^4.17.21
       react: 17.0.2
       react-dom: 17.0.2
       sass: ^1.53.0
@@ -45,12 +43,10 @@ importers:
       vite-plugin-html: ^3.2.0
     dependencies:
       '@kseniass/react-flow-editor': file:packages/react-flow-editor_sfoxds7t5ydpegc3knd667wn6m
-      lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       sass: 1.56.0
     devDependencies:
-      '@types/lodash': 4.14.188
       '@types/react': 17.0.30
       '@types/react-dom': 18.0.8
       '@vitejs/plugin-react': 1.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ importers:
       '@kseniass/react-flow-editor': file:../react-flow-editor/
       '@types/lodash': ^4.14.182
       '@types/react': 17.0.30
+      '@types/react-dom': ^18.0.8
       '@vitejs/plugin-react': ^1.3.2
       eslint: ^8.20.0
       lodash: ^4.17.21
@@ -51,6 +52,7 @@ importers:
     devDependencies:
       '@types/lodash': 4.14.188
       '@types/react': 17.0.30
+      '@types/react-dom': 18.0.8
       '@vitejs/plugin-react': 1.3.2
       eslint: 8.27.0
       typescript: 4.8.4
@@ -594,6 +596,12 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+    dev: true
+
+  /@types/react-dom/18.0.8:
+    resolution: {integrity: sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==}
+    dependencies:
+      '@types/react': 17.0.30
     dev: true
 
   /@types/react/17.0.30:


### PR DESCRIPTION
Example contains a lot of less code, `useMemo` and `useContext` should't be there