### PR TITLE
fixes on node dragging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Version 1.0.1
+
+##### Style fixes
+
+- Cursor has grabbing style if node state is dragging. Also dragging node z-index was increased.
+
+##### Functionality fixes
+
+- Canvas mouseDown capture on drilling
+
 ### Version 1.0.0
 
 ##### style fixes

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Version 1.0.1
+### Version 1.0.3
 
 ##### Style fixes
 

--- a/packages/examples/src/simple.scss
+++ b/packages/examples/src/simple.scss
@@ -111,6 +111,9 @@ body {
   box-sizing: content-box;
   z-index: 1;
   width: 150px;
+  height: 60px;
+  padding: 10px;
+  box-sizing: border-box;
 
   transition: $node-transitions;
 

--- a/packages/examples/src/simple.tsx
+++ b/packages/examples/src/simple.tsx
@@ -14,7 +14,7 @@ import { initialNodes, STYLED_CONFIG, TIPS, OUTPUT_STYLES } from "./constants"
 import { nodeFactory } from "./helpers"
 import { NodeAttributes } from "./parts"
 
-const NodeComponent = (_: Node) => <div>Node</div>
+const NodeComponent = (_: Node) => <div className="nodeElement">Node</div>
 
 const SelectionZoneComponent = () => <div className="selection-zone" />
 

--- a/packages/react-flow-editor/package.json
+++ b/packages/react-flow-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kseniass/react-flow-editor",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "React component which enables creating flow editors with ease",
   "repository": {
     "type": "git",

--- a/packages/react-flow-editor/src/Editor/Canvas.tsx
+++ b/packages/react-flow-editor/src/Editor/Canvas.tsx
@@ -34,10 +34,10 @@ export const Canvas: React.FC<Props> = ({ SelectionZoneComponent, ScaleComponent
   return (
     <RectsContext.Provider value={{ zoomContainerRef, editorContainerRef }}>
       <div
-        onMouseUp={onDragEnded}
+        onMouseUpCapture={onDragEnded}
         onMouseMove={onDrag}
         onWheel={onWheel}
-        onMouseDown={onDragStarted}
+        onMouseDownCapture={onDragStarted}
         ref={editorContainerRef}
         className="react-flow-editor"
       >

--- a/packages/react-flow-editor/src/Editor/components/Node/helpers.ts
+++ b/packages/react-flow-editor/src/Editor/components/Node/helpers.ts
@@ -1,7 +1,9 @@
-import { Point } from "@/types"
+import { NodeState, Point } from "@/types"
 
-export const nodeStyle = (pos: Point) => ({
-  transform: `translate(${pos.x}px, ${pos.y}px)`
+export const nodeStyle = (pos: Point, state: NodeState | null) => ({
+  transform: `translate(${pos.x}px, ${pos.y}px)`,
+  cursor: state === NodeState.dragging ? "grabbing" : "pointer",
+  zIndex: state === NodeState.dragging ? 2 : 1
 })
 
 export const buildDotId = (nodeId: string) => `dot-${nodeId}`

--- a/packages/react-flow-editor/src/Editor/components/Node/node.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Node/node.tsx
@@ -40,7 +40,7 @@ const Node: React.FC<
       className="node"
       onMouseDown={nodeInteractions.onDragStarted}
       onMouseUp={nodeInteractions.onMouseUp}
-      style={nodeStyle(node.position)}
+      style={nodeStyle(node.position, node.state)}
       onMouseEnter={nodeInteractions.onMouseEnter}
       onMouseLeave={nodeInteractions.onMouseLeave}
     >


### PR DESCRIPTION
Some moments was fixed
1. Grabbing pointer style on node dragging
2. Dragging node z-index
3. Canvas mousedown/up actions triggers on capture. It needs if custom node element will use `stopPropagation`, but lib should update it's node states on mousedown/up
4. Recover preview example node blocks styles