### PR TITLE
1.1.2 Correct background movement

### DIFF
--- a/packages/react-flow-editor/package.json
+++ b/packages/react-flow-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kseniass/react-flow-editor",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "description": "React component which enables creating flow editors with ease",
   "repository": {
     "type": "git",

--- a/packages/react-flow-editor/package.json
+++ b/packages/react-flow-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kseniass/react-flow-editor",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React component which enables creating flow editors with ease",
   "repository": {
     "type": "git",

--- a/packages/react-flow-editor/src/Editor/components/Background/Background.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Background/Background.tsx
@@ -3,6 +3,7 @@ import React, { FC } from "react"
 
 import { TransformationMap } from "@/Editor/state"
 
+import { usePatternDimensions } from "./hooks"
 import { BackgroundProps, BackgroundVariant } from "./types"
 import { createGridLinesPath, createGridDotsPath } from "./utils"
 
@@ -14,10 +15,7 @@ const defaultColors = {
 
 const Background: FC<BackgroundProps> = ({ variant = BackgroundVariant.Dots, gap = 15, size = 0.4, color }) => {
   const transformation = useStore(TransformationMap)
-
-  const scaledGap = gap * transformation.zoom || 1
-  const xOffset = transformation.dx % scaledGap
-  const yOffset = transformation.dy % scaledGap
+  const { scaledGap, xOffset, yOffset } = usePatternDimensions(gap)
 
   const bgColor = color || defaultColors[`${variant}`]
   const path =

--- a/packages/react-flow-editor/src/Editor/components/Background/helpers.ts
+++ b/packages/react-flow-editor/src/Editor/components/Background/helpers.ts
@@ -1,0 +1,2 @@
+export const countOffset = (offset: number, zoom: number, editorDimension?: number): number =>
+  offset * zoom + (editorDimension || 0) / 2

--- a/packages/react-flow-editor/src/Editor/components/Background/hooks.ts
+++ b/packages/react-flow-editor/src/Editor/components/Background/hooks.ts
@@ -1,0 +1,21 @@
+import { useStore } from "@nanostores/react"
+import { useContext } from "react"
+
+import { TransformationMap } from "@/Editor/state"
+import { RectsContext } from "@/Editor/context"
+
+import { PatternDimensions } from "./types"
+import { countOffset } from "./helpers"
+
+export const usePatternDimensions = (gap: number): PatternDimensions => {
+  const { editorContainerRef } = useContext(RectsContext)
+  const editorRect = editorContainerRef.current?.getBoundingClientRect()
+
+  const transformation = useStore(TransformationMap)
+
+  return {
+    scaledGap: gap * transformation.zoom || 1,
+    xOffset: countOffset(transformation.dx, transformation.zoom, editorRect?.width),
+    yOffset: countOffset(transformation.dy, transformation.zoom, editorRect?.height)
+  }
+}

--- a/packages/react-flow-editor/src/Editor/components/Background/types.ts
+++ b/packages/react-flow-editor/src/Editor/components/Background/types.ts
@@ -11,3 +11,9 @@ export interface BackgroundProps extends HTMLAttributes<SVGElement> {
   color?: string
   size?: number
 }
+
+export type PatternDimensions = {
+  scaledGap: number
+  xOffset: number
+  yOffset: number
+}

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/ArrowDisconnector.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/ArrowDisconnector.tsx
@@ -3,8 +3,15 @@ import { useStore } from "@nanostores/react"
 
 import { NodeState, Output, Point } from "@/types"
 import { DragItemType } from "@/Editor/types"
-import { EditorContext, RectsContext } from "@/Editor/context"
-import { DragItemAtom, NewConnectionAtom, nodeActions, NodesAtom, SvgOffsetAtom } from "@/Editor/state"
+import { RectsContext } from "@/Editor/context"
+import {
+  DragItemAtom,
+  NewConnectionAtom,
+  nodeActions,
+  NodesAtom,
+  SvgOffsetAtom,
+  TransformationMap
+} from "@/Editor/state"
 import { getRectFromRef } from "@/Editor/helpers/getRectFromRef"
 
 import { disconnectorStyle } from "../helpers"
@@ -18,7 +25,7 @@ type DisconnectorProps = {
 
 const ArrowDisconnector: React.FC<DisconnectorProps> = ({ position, fromId, output }) => {
   const { zoomContainerRef } = useContext(RectsContext)
-  const { transformation } = useContext(EditorContext)
+  const transformation = useStore(TransformationMap)
   const svgOffset = useStore(SvgOffsetAtom)
   const nodes = useStore(NodesAtom)
 


### PR DESCRIPTION
Bugfixes:

1. Different move speed of nodes and canvas dots while dragging canvas (if zoom is not equal to 1)
2. Incorrect transform origin of background dots while scaling. It was fixed to make scale relatively to center (central canvas dot must be fixed).
3. Console error of missed transformation in Arrow Disconnector (and incorrect behavior as a consequences)