### PR TITLE
Chore/correct renders

### DIFF
--- a/packages/react-flow-editor/package.json
+++ b/packages/react-flow-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kseniass/react-flow-editor",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "React component which enables creating flow editors with ease",
   "repository": {
     "type": "git",

--- a/packages/react-flow-editor/src/Editor/Canvas.tsx
+++ b/packages/react-flow-editor/src/Editor/Canvas.tsx
@@ -9,7 +9,7 @@ import useDnD from "./helpers/DnD"
 import { useZoom } from "./helpers/zoom"
 import { useHotKeys } from "./helpers/hotKeys"
 import { NodesContainer } from "./components/Node"
-import { RectsContext } from "./context"
+import { RectsContext } from "./rects-context"
 import { TransformationMap } from "./state"
 import { SelectionZone } from "./components/SelectionZone"
 import { Scale } from "./components/Scale"
@@ -20,8 +20,8 @@ type Props = {
 }
 
 export const Canvas: React.FC<Props> = ({ SelectionZoneComponent, ScaleComponent }) => {
-  const zoomContainerRef = useRef<HTMLDivElement>(null)
-  const editorContainerRef = useRef<HTMLDivElement>(null)
+  const zoomContainerRef = useRef<HTMLDivElement>(document.querySelector(".zoom-container")!)
+  const editorContainerRef = useRef<HTMLDivElement>(document.querySelector(".react-flow-editor")!)
 
   const transformation = useStore(TransformationMap)
 
@@ -32,7 +32,9 @@ export const Canvas: React.FC<Props> = ({ SelectionZoneComponent, ScaleComponent
   useHotKeys()
 
   return (
-    <RectsContext.Provider value={{ zoomContainerRef, editorContainerRef }}>
+    <RectsContext.Provider
+      value={{ zoomContainer: zoomContainerRef.current, editorContainer: editorContainerRef.current }}
+    >
       <div
         onMouseUpCapture={onDragEnded}
         onMouseMove={onDrag}

--- a/packages/react-flow-editor/src/Editor/Editor.tsx
+++ b/packages/react-flow-editor/src/Editor/Editor.tsx
@@ -1,10 +1,9 @@
-import React, { memo } from "react"
-import { isEqual } from "lodash"
+import React from "react"
 
 import type { EditorProps } from "@/types"
 
 import { Canvas } from "./Canvas"
-import { EditorContext } from "./context"
+import { EditorContext } from "./editor-context"
 import "../_style.scss"
 import { StoreUpdater } from "./StoreUpdater"
 
@@ -39,4 +38,5 @@ const Editor: React.FC<EditorProps> = ({
     />
   </EditorContext.Provider>
 )
-export default memo(Editor, isEqual)
+
+export default Editor

--- a/packages/react-flow-editor/src/Editor/StoreUpdater.ts
+++ b/packages/react-flow-editor/src/Editor/StoreUpdater.ts
@@ -18,13 +18,21 @@ const synchronizeWithStore = <T extends Record<string, unknown> | Array<unknown>
   storeEntity: WritableAtom<T> | MapStore<T>,
   updateEntity?: (entity: T) => void
 ) => {
+  let unsubCallback: (() => void) | null = null
+
   useEffect(() => {
     storeEntity.set(entity)
   }, [entity])
 
   useEffect(() => {
-    if (updateEntity) {
-      storeEntity.subscribe((value) => updateEntity(value))
+    if (updateEntity && !unsubCallback) {
+      unsubCallback = storeEntity.subscribe((value) => updateEntity(value))
+    }
+
+    return () => {
+      if (unsubCallback) {
+        unsubCallback()
+      }
     }
   }, [updateEntity])
 }

--- a/packages/react-flow-editor/src/Editor/components/Background/hooks.ts
+++ b/packages/react-flow-editor/src/Editor/components/Background/hooks.ts
@@ -1,15 +1,14 @@
 import { useStore } from "@nanostores/react"
-import { useContext } from "react"
 
 import { TransformationMap } from "@/Editor/state"
-import { RectsContext } from "@/Editor/context"
+import { useRectsContext } from "@/Editor/rects-context"
 
 import { PatternDimensions } from "./types"
 import { countOffset } from "./helpers"
 
 export const usePatternDimensions = (gap: number): PatternDimensions => {
-  const { editorContainerRef } = useContext(RectsContext)
-  const editorRect = editorContainerRef.current?.getBoundingClientRect()
+  const { editorContainer } = useRectsContext()
+  const editorRect = editorContainer?.getBoundingClientRect()
 
   const transformation = useStore(TransformationMap)
 

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/ArrowDisconnector.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/ArrowDisconnector.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useContext } from "react"
+import React, { useCallback } from "react"
 import { useStore } from "@nanostores/react"
 
 import { NodeState, Output, Point } from "@/types"
 import { DragItemType } from "@/Editor/types"
-import { RectsContext } from "@/Editor/context"
 import {
   DragItemAtom,
   NewConnectionAtom,
@@ -12,7 +11,7 @@ import {
   SvgOffsetAtom,
   TransformationMap
 } from "@/Editor/state"
-import { getRectFromRef } from "@/Editor/helpers/getRectFromRef"
+import { useRectsContext } from "@/Editor/rects-context"
 
 import { disconnectorStyle } from "../helpers"
 import { markDisabledNodes } from "../../Node/helpers"
@@ -24,7 +23,7 @@ type DisconnectorProps = {
 }
 
 const ArrowDisconnector: React.FC<DisconnectorProps> = ({ position, fromId, output }) => {
-  const { zoomContainerRef } = useContext(RectsContext)
+  const { zoomContainer } = useRectsContext()
   const transformation = useStore(TransformationMap)
   const svgOffset = useStore(SvgOffsetAtom)
   const nodes = useStore(NodesAtom)
@@ -44,7 +43,7 @@ const ArrowDisconnector: React.FC<DisconnectorProps> = ({ position, fromId, outp
         y: e.clientY
       })
 
-      const zoomRect = getRectFromRef(zoomContainerRef)
+      const zoomRect = zoomContainer.getBoundingClientRect()
 
       const newPos = {
         x: (e.clientX - zoomRect.left) / transformation.zoom - svgOffset.x,
@@ -55,7 +54,7 @@ const ArrowDisconnector: React.FC<DisconnectorProps> = ({ position, fromId, outp
 
       nodeActions.changeNodeState(fromId, NodeState.draggingConnector)
     },
-    [transformation, zoomContainerRef, svgOffset]
+    [transformation, zoomContainer, svgOffset]
   )
 
   return <rect onMouseDown={onMouseDown} className="disconnector" style={disconnectorStyle(position)} />

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/ArrowDisconnector.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/ArrowDisconnector.tsx
@@ -1,20 +1,10 @@
-import React, { useCallback } from "react"
-import { useStore } from "@nanostores/react"
+import React from "react"
 
-import { NodeState, Output, Point } from "@/types"
-import { DragItemType } from "@/Editor/types"
-import {
-  DragItemAtom,
-  NewConnectionAtom,
-  nodeActions,
-  NodesAtom,
-  SvgOffsetAtom,
-  TransformationMap
-} from "@/Editor/state"
+import { Output, Point } from "@/types"
+import { newConnectionActions } from "@/Editor/state"
 import { useRectsContext } from "@/Editor/rects-context"
 
 import { disconnectorStyle } from "../helpers"
-import { markDisabledNodes } from "../../Node/helpers"
 
 type DisconnectorProps = {
   position: Point
@@ -24,38 +14,13 @@ type DisconnectorProps = {
 
 const ArrowDisconnector: React.FC<DisconnectorProps> = ({ position, fromId, output }) => {
   const { zoomContainer } = useRectsContext()
-  const transformation = useStore(TransformationMap)
-  const svgOffset = useStore(SvgOffsetAtom)
-  const nodes = useStore(NodesAtom)
 
-  const onMouseDown = useCallback(
-    (e) => {
-      e.stopPropagation()
+  const onMouseDown = (e: React.MouseEvent<SVGRectElement>) => {
+    e.stopPropagation()
+    const zoomRect = zoomContainer.getBoundingClientRect()
 
-      const fromNode = nodes.find((node) => node.id === fromId)!
-      markDisabledNodes(fromNode, nodes)
-
-      DragItemAtom.set({
-        type: DragItemType.connection,
-        id: fromId,
-        output,
-        x: e.clientX,
-        y: e.clientY
-      })
-
-      const zoomRect = zoomContainer.getBoundingClientRect()
-
-      const newPos = {
-        x: (e.clientX - zoomRect.left) / transformation.zoom - svgOffset.x,
-        y: (e.clientY - zoomRect.top) / transformation.zoom - svgOffset.y
-      }
-
-      NewConnectionAtom.set(newPos)
-
-      nodeActions.changeNodeState(fromId, NodeState.draggingConnector)
-    },
-    [transformation, zoomContainer, svgOffset]
-  )
+    newConnectionActions.dragArrowDisconnector(e, fromId, output, zoomRect)
+  }
 
   return <rect onMouseDown={onMouseDown} className="disconnector" style={disconnectorStyle(position)} />
 }

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/Connection.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/Connection.tsx
@@ -14,11 +14,12 @@ type ConnectionProps = {
 
 export const ConnectionTrack: React.FC<{ output: Output; node: Node }> = ({ output, node }) => {
   const nodes = useStore(NodesAtom)
-  const svgOffset = useStore(SvgOffsetAtom)
 
   const nextNode = nodes.find((node) => node.id === output.nextNodeId)
 
   if (!nextNode) return null
+
+  const svgOffset = SvgOffsetAtom.get()
 
   const outputPosition = node.rectPosition
     ? {

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
@@ -1,9 +1,9 @@
 import { isEqual } from "lodash"
-import React, { useContext } from "react"
+import React from "react"
 
 import { Point } from "@/types"
 import { DEFAULT_COLOR } from "@/Editor/constants"
-import { EditorContext } from "@/Editor/context"
+import { useEditorContext } from "@/Editor/editor-context"
 
 import { ARROW_ID } from "./Arrow"
 
@@ -13,7 +13,7 @@ type InputConnectionProps = {
 }
 
 const InputConnection: React.FC<InputConnectionProps> = ({ inputPosition, outputPosition }) => {
-  const { connectorStyleConfig } = useContext(EditorContext)
+  const { connectorStyleConfig } = useEditorContext()
 
   const dx = Math.max(Math.abs(inputPosition.x - outputPosition.x) / 1.5, 100)
   const a1 = { x: inputPosition.x - dx, y: inputPosition.y }

--- a/packages/react-flow-editor/src/Editor/components/Connections/index.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react"
+import React, { useEffect } from "react"
 import { useStore } from "@nanostores/react"
 
 import { NodesAtom, SvgOffsetAtom, TransformationMap } from "@/Editor/state"
@@ -7,10 +7,10 @@ import { Connection } from "./components/Connection"
 import { NewConnection } from "./components/NewConnection"
 import { computeNodeGroupsRect, connectionContainerStyle } from "./helpers"
 import { Arrow } from "./components/Arrow"
-import { EditorContext } from "../../context"
+import { useEditorContext } from "../../editor-context"
 
 export const Container: React.FC = () => {
-  const { connectorStyleConfig } = useContext(EditorContext)
+  const { connectorStyleConfig } = useEditorContext()
   const nodes = useStore(NodesAtom)
   const transformation = useStore(TransformationMap)
 

--- a/packages/react-flow-editor/src/Editor/components/Node/helpers.ts
+++ b/packages/react-flow-editor/src/Editor/components/Node/helpers.ts
@@ -1,5 +1,4 @@
-import { nodeActions } from "@/Editor/state"
-import { NodeState, Point, Node } from "@/types"
+import { NodeState, Point } from "@/types"
 
 export const nodeStyle = (pos: Point, state: NodeState | null) => ({
   transform: `translate(${pos.x}px, ${pos.y}px)`,
@@ -8,16 +7,3 @@ export const nodeStyle = (pos: Point, state: NodeState | null) => ({
 })
 
 export const buildDotId = (nodeId: string) => `dot-${nodeId}`
-
-const isNoNodeFreeInputs = (node: Node, nodes: Node[]): boolean =>
-  nodes.filter((curNode) => curNode.outputs.map((out) => out.nextNodeId).includes(node.id)).length === node.inputNumber
-
-const notTheSameNode = (connectableNode: Node, curNode: Node): boolean => curNode.id !== connectableNode.id
-
-export const markDisabledNodes = (connectableNode: Node, nodes: Node[]) => {
-  const disabledNodesIds = nodes
-    .filter((curNode) => notTheSameNode(connectableNode, curNode) && isNoNodeFreeInputs(curNode, nodes))
-    .map((curNode) => curNode.id)
-
-  nodeActions.changeNodesState(disabledNodesIds, NodeState.disabled)
-}

--- a/packages/react-flow-editor/src/Editor/components/Node/node.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Node/node.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react"
+import React, { useEffect } from "react"
 import { isEqual } from "lodash"
 
 import { Node as NodeType } from "@/types"
@@ -6,7 +6,7 @@ import { nodeActions } from "@/Editor/state"
 
 import { nodeStyle } from "./helpers"
 import { useNodeInteractions } from "./useNodeInteractions"
-import { EditorContext } from "../../context"
+import { useEditorContext } from "../../editor-context"
 import { Output } from "../Output"
 
 type NodeProps = {
@@ -32,7 +32,7 @@ const Node: React.FC<
     nodeInteractions: ReturnType<typeof useNodeInteractions>
   }
 > = ({ node, nodeInteractions }) => {
-  const { NodeComponent } = useContext(EditorContext)
+  const { NodeComponent } = useEditorContext()
 
   return (
     <div

--- a/packages/react-flow-editor/src/Editor/components/Node/node.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Node/node.tsx
@@ -45,7 +45,7 @@ const Node: React.FC<
       onMouseLeave={nodeInteractions.onMouseLeave}
     >
       {node.outputs.map((out) => (
-        <Output key={out.id} node={node} output={out} />
+        <Output key={out.id} nodeId={node.id} nodeState={node.state} output={out} />
       ))}
       <NodeComponent {...node} />
     </div>

--- a/packages/react-flow-editor/src/Editor/components/Node/useNodeInteractions.ts
+++ b/packages/react-flow-editor/src/Editor/components/Node/useNodeInteractions.ts
@@ -8,7 +8,6 @@ import { BUTTON_LEFT } from "../../constants"
 import { DragItemType } from "../../types"
 
 export const useNodeInteractions = (node: Node) => {
-  const nodes = useStore(NodesAtom)
   const dragItem = useStore(DragItemAtom)
   const [initialClickCoords, setInitialClickCoords] = useState<Point>({ x: 0, y: 0 })
 
@@ -25,7 +24,7 @@ export const useNodeInteractions = (node: Node) => {
     (e) => {
       if (e.button === BUTTON_LEFT) {
         NodesAtom.set(
-          nodes.map((nodeItem) => {
+          NodesAtom.get().map((nodeItem) => {
             const isSelected =
               (nodeItem.id === node.id && initialClickCoords.x === e.clientX && initialClickCoords.y === e.clientY) ||
               (e.shiftKey && nodeItem.state === NodeState.dragging)
@@ -55,12 +54,12 @@ export const useNodeInteractions = (node: Node) => {
         DragItemAtom.set({ type: undefined, x: e.clientX, y: e.clientY })
       }
     },
-    [initialClickCoords, nodes]
+    [initialClickCoords]
   )
 
   const onMouseEnter: React.MouseEventHandler<HTMLDivElement> = useCallback(() => {
     HoveredNodeIdAtom.set(node.id)
-  }, [dragItem.id, nodes])
+  }, [dragItem.id])
 
   const onMouseLeave: React.MouseEventHandler<HTMLDivElement> = useCallback(() => {
     HoveredNodeIdAtom.set(null)

--- a/packages/react-flow-editor/src/Editor/components/Output/index.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Output/index.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from "lodash"
-import React, { useContext } from "react"
+import React from "react"
 import { useStore } from "@nanostores/react"
 
 import { Node, NodeState, Output as OutputType } from "@/types"
@@ -11,10 +11,10 @@ import {
   SvgOffsetAtom,
   TransformationMap
 } from "@/Editor/state"
-import { getRectFromRef } from "@/Editor/helpers/getRectFromRef"
+import { useRectsContext } from "@/Editor/rects-context"
 
 import { BUTTON_LEFT } from "../../constants"
-import { EditorContext, RectsContext } from "../../context"
+import { useEditorContext } from "../../editor-context"
 import { resetEvent } from "../../helpers"
 import { DragItemType } from "../../types"
 import { markDisabledNodes } from "../Node/helpers"
@@ -25,15 +25,15 @@ type Props = {
 }
 
 export const Output: React.FC<Props> = React.memo(({ node, output }) => {
-  const { OutputComponent } = useContext(EditorContext)
-  const { zoomContainerRef } = useContext(RectsContext)
+  const { OutputComponent } = useEditorContext()
+  const { zoomContainer } = useRectsContext()
   const svgOffset = useStore(SvgOffsetAtom)
   const transformation = useStore(TransformationMap)
   const dragItem = useStore(DragItemAtom)
   const nodes = useStore(NodesAtom)
 
   const startNewConnection = (e: React.MouseEvent<HTMLElement>) => {
-    const zoomRect = getRectFromRef(zoomContainerRef)
+    const zoomRect = zoomContainer.getBoundingClientRect()
 
     resetEvent(e)
     if (e.button === BUTTON_LEFT) {

--- a/packages/react-flow-editor/src/Editor/components/Output/index.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Output/index.tsx
@@ -2,59 +2,31 @@ import { isEqual } from "lodash"
 import React from "react"
 import { useStore } from "@nanostores/react"
 
-import { Node, NodeState, Output as OutputType } from "@/types"
-import {
-  DragItemAtom,
-  NewConnectionAtom,
-  nodeActions,
-  NodesAtom,
-  SvgOffsetAtom,
-  TransformationMap
-} from "@/Editor/state"
+import { NodeState, Output as OutputType } from "@/types"
+import { DragItemAtom, newConnectionActions } from "@/Editor/state"
 import { useRectsContext } from "@/Editor/rects-context"
 
 import { BUTTON_LEFT } from "../../constants"
 import { useEditorContext } from "../../editor-context"
 import { resetEvent } from "../../helpers"
-import { DragItemType } from "../../types"
-import { markDisabledNodes } from "../Node/helpers"
 
 type Props = {
-  node: Node
+  nodeId: string
+  nodeState: NodeState | null
   output: OutputType
 }
 
-export const Output: React.FC<Props> = React.memo(({ node, output }) => {
+export const Output: React.FC<Props> = React.memo(({ nodeId, nodeState, output }) => {
   const { OutputComponent } = useEditorContext()
   const { zoomContainer } = useRectsContext()
-  const svgOffset = useStore(SvgOffsetAtom)
-  const transformation = useStore(TransformationMap)
   const dragItem = useStore(DragItemAtom)
-  const nodes = useStore(NodesAtom)
 
   const startNewConnection = (e: React.MouseEvent<HTMLElement>) => {
     const zoomRect = zoomContainer.getBoundingClientRect()
 
     resetEvent(e)
     if (e.button === BUTTON_LEFT) {
-      nodeActions.changeNodeState(node.id, NodeState.draggingConnector)
-
-      const pos = {
-        x: -svgOffset.x + (e.clientX - zoomRect.left) / transformation.zoom,
-        y: -svgOffset.y + (e.clientY - zoomRect.top) / transformation.zoom
-      }
-
-      NewConnectionAtom.set(pos)
-
-      DragItemAtom.set({
-        type: DragItemType.connection,
-        output,
-        id: node.id,
-        x: e.clientX,
-        y: e.clientY
-      })
-
-      markDisabledNodes(node, nodes)
+      newConnectionActions.startNewConnection(nodeId, zoomRect, e, output)
     }
   }
 
@@ -72,7 +44,7 @@ export const Output: React.FC<Props> = React.memo(({ node, output }) => {
         transform: "translate(-50%, -50%)"
       }}
     >
-      <OutputComponent active={isActive} nodeState={node.state} />
+      <OutputComponent active={isActive} nodeState={nodeState} />
     </div>
   )
 }, isEqual)

--- a/packages/react-flow-editor/src/Editor/components/Scale/useOverview.ts
+++ b/packages/react-flow-editor/src/Editor/components/Scale/useOverview.ts
@@ -1,12 +1,12 @@
 import { useStore } from "@nanostores/react"
-import { useContext, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { NodesAtom, TransformationMap } from "@/Editor/state"
-import { RectsContext } from "@/Editor/context"
 import { DRAG_OFFSET_TRANSFORM, LARGEST_RECT } from "@/Editor/constants"
+import { useRectsContext } from "@/Editor/rects-context"
 
 export const useOverview = () => {
-  const { zoomContainerRef, editorContainerRef } = useContext(RectsContext)
+  const { zoomContainer, editorContainer } = useRectsContext()
 
   const nodes = useStore(NodesAtom)
   const transformation = useStore(TransformationMap)
@@ -15,9 +15,7 @@ export const useOverview = () => {
   useEffect(() => {
     if (underOverview) {
       if (nodes.length) {
-        if (!editorContainerRef.current || !zoomContainerRef.current) return
-
-        const editorRect = editorContainerRef.current?.getBoundingClientRect()
+        const editorRect = editorContainer.getBoundingClientRect()
 
         const dimensionsRect = nodes.reduce(
           (acc, node) => {
@@ -45,7 +43,7 @@ export const useOverview = () => {
         const dx = -dimensionsRect.leftPoint + (editorRect.width - width) / 2
         const dy = -dimensionsRect.topPoint + (editorRect.height - height) / 2
 
-        zoomContainerRef.current.style.transformOrigin = `${dx}px ${dy}px`
+        zoomContainer.style.transformOrigin = `${dx}px ${dy}px`
 
         TransformationMap.set({
           dx,
@@ -56,7 +54,7 @@ export const useOverview = () => {
 
       setUnderOverview(false)
     }
-  }, [underOverview, nodes, transformation, editorContainerRef])
+  }, [underOverview, nodes, transformation, editorContainer])
 
   /** Overview on mount */
   useEffect(() => {

--- a/packages/react-flow-editor/src/Editor/components/Scale/useOverview.ts
+++ b/packages/react-flow-editor/src/Editor/components/Scale/useOverview.ts
@@ -8,12 +8,13 @@ import { useRectsContext } from "@/Editor/rects-context"
 export const useOverview = () => {
   const { zoomContainer, editorContainer } = useRectsContext()
 
-  const nodes = useStore(NodesAtom)
   const transformation = useStore(TransformationMap)
   const [underOverview, setUnderOverview] = useState<boolean>(false)
 
   useEffect(() => {
     if (underOverview) {
+      const nodes = NodesAtom.get()
+
       if (nodes.length) {
         const editorRect = editorContainer.getBoundingClientRect()
 
@@ -54,7 +55,7 @@ export const useOverview = () => {
 
       setUnderOverview(false)
     }
-  }, [underOverview, nodes, transformation, editorContainer])
+  }, [underOverview, transformation, editorContainer])
 
   /** Overview on mount */
   useEffect(() => {

--- a/packages/react-flow-editor/src/Editor/constants.ts
+++ b/packages/react-flow-editor/src/Editor/constants.ts
@@ -9,8 +9,8 @@ export const ZOOM_MAX = 3
 export const ZOOM_MIN = 0.2
 
 export const DRAG_OFFSET_TRANSFORM = 80
-export const DRAG_AUTO_SCROLL_DIST = 30
-export const DRAG_AUTO_SCROLL_TIME = 10
+export const DRAG_AUTO_SCROLL_DIST = 25
+export const DRAG_AUTO_SCROLL_TIME = 6
 
 export const DEFAULT_POINT_SIZE = 8
 export const DEFAULT_COLOR = "black"

--- a/packages/react-flow-editor/src/Editor/editor-context.ts
+++ b/packages/react-flow-editor/src/Editor/editor-context.ts
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react"
+
+export const EditorContext = createContext<any>({} as any)
+
+export const useEditorContext = () => useContext(EditorContext)

--- a/packages/react-flow-editor/src/Editor/helpers/DnD/index.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/DnD/index.ts
@@ -23,8 +23,6 @@ export default ({
   zoomContainerRef: React.RefObject<HTMLDivElement>
   editorContainerRef: React.RefObject<HTMLDivElement>
 }) => {
-  const nodes = useStore(NodesAtom)
-  const hoveredNodeId = useStore(HoveredNodeIdAtom)
   const dragItem = useStore(DragItemAtom)
 
   const checkAutoScrollEnable = useAutoScroll(editorContainerRef)
@@ -51,6 +49,9 @@ export default ({
     }
 
     if (dragItem.type === DragItemType.connection) {
+      const hoveredNodeId = HoveredNodeIdAtom.get()
+      const nodes = NodesAtom.get()
+
       const inputNode = nodes.find((currentElement) => hoveredNodeId === currentElement.id)!
       const outputNode = nodes.find((node) => node.id === dragItem.id)
 

--- a/packages/react-flow-editor/src/Editor/helpers/DnD/index.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/DnD/index.ts
@@ -12,7 +12,7 @@ import {
 import { BUTTON_LEFT } from "../../constants"
 import { DragItemType } from "../../types"
 import { useAutoScroll } from "../autoScroll"
-import { useSelectionZone } from "../selectionZone"
+import { useSelectionZone } from "../useSelectionZone"
 import { useDragTransformations } from "./useDragTransformations"
 import { isNodesHaveStateToReset } from "./helpers"
 

--- a/packages/react-flow-editor/src/Editor/helpers/DnD/useDragTransformations.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/DnD/useDragTransformations.ts
@@ -1,17 +1,6 @@
-import { useStore } from "@nanostores/react"
-
-import { NodeState } from "@/types"
-import {
-  DragItemAtom,
-  NewConnectionAtom,
-  NodesAtom,
-  SelectionZoneAtom,
-  SvgOffsetAtom,
-  TransformationMap
-} from "@/Editor/state"
+import { newConnectionActions, nodeActions, transformationActions } from "@/Editor/state"
 
 import { DragItemType } from "../../types"
-import { isNodeInSelectionZone } from "../selectionZone"
 import { getRectFromRef } from "../getRectFromRef"
 
 export const useDragTransformations = ({
@@ -21,65 +10,22 @@ export const useDragTransformations = ({
   expandSelectionZone: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void
   zoomContainerRef: React.RefObject<HTMLDivElement>
 }) => {
-  const transformation = useStore(TransformationMap)
-  const nodes = useStore(NodesAtom)
-  const svgOffset = useStore(SvgOffsetAtom)
-  const selectionZone = useStore(SelectionZoneAtom)
-  const dragItem = useStore(DragItemAtom)
-
   const zoomRect = getRectFromRef(zoomContainerRef)
 
   return {
     [DragItemType.connection]: (e: React.MouseEvent<HTMLElement>) => {
-      const newPos = {
-        x: (e.clientX - zoomRect.left) / transformation.zoom - svgOffset.x,
-        y: (e.clientY - zoomRect.top) / transformation.zoom - svgOffset.y
-      }
-
-      NewConnectionAtom.set(newPos)
+      newConnectionActions.dragNewConnectionHandler(e, zoomRect)
     },
 
     [DragItemType.viewPort]: (e: React.MouseEvent<HTMLElement>) => {
-      const newPos = {
-        x: (e.clientX - dragItem.x) / transformation.zoom,
-        y: (e.clientY - dragItem.y) / transformation.zoom
-      }
-
-      TransformationMap.set({
-        ...transformation,
-        dx: transformation.dx + newPos.x,
-        dy: transformation.dy + newPos.y
-      })
+      transformationActions.dragViewportHandler(e)
     },
     [DragItemType.node]: (e: React.MouseEvent<HTMLElement>) => {
-      NodesAtom.set(
-        nodes.map((el) => {
-          const isDragging = el.id === dragItem.id
-          const isShiftSelected = e.shiftKey && el.state === NodeState.selected
-
-          return isDragging || isShiftSelected
-            ? {
-                ...el,
-                position: {
-                  x: el.position.x + (e.clientX - dragItem.x) / transformation.zoom,
-                  y: el.position.y + (e.clientY - dragItem.y) / transformation.zoom
-                },
-                rectPosition: document.getElementById(el.id)?.getBoundingClientRect(),
-                state: isShiftSelected ? NodeState.selected : NodeState.dragging
-              }
-            : { ...el, state: null }
-        })
-      )
+      nodeActions.dragNodeHandler(e)
     },
     [DragItemType.selectionZone]: (e: React.MouseEvent<HTMLElement>) => {
       expandSelectionZone(e)
-
-      NodesAtom.set(
-        nodes.map((el) => ({
-          ...el,
-          state: isNodeInSelectionZone(el, selectionZone, transformation) ? NodeState.selected : null
-        }))
-      )
+      nodeActions.dragSelectionZoneHandler()
     }
   }
 }

--- a/packages/react-flow-editor/src/Editor/helpers/hotKeys.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/hotKeys.ts
@@ -1,13 +1,13 @@
 import { useStore } from "@nanostores/react"
-import { useContext, useEffect } from "react"
+import { useEffect } from "react"
 
 import { NodeState } from "../../types"
 import { KEY_CODE_BACK, KEY_CODE_DELETE } from "../constants"
-import { EditorContext } from "../context"
+import { useEditorContext } from "../editor-context"
 import { NodesAtom } from "../state"
 
 export const useHotKeys = () => {
-  const { importantNodeIds } = useContext(EditorContext)
+  const { importantNodeIds } = useEditorContext()
   const nodes = useStore(NodesAtom)
 
   useEffect(() => {

--- a/packages/react-flow-editor/src/Editor/helpers/hotKeys.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/hotKeys.ts
@@ -1,4 +1,3 @@
-import { useStore } from "@nanostores/react"
 import { useEffect } from "react"
 
 import { NodeState } from "../../types"
@@ -8,11 +7,12 @@ import { NodesAtom } from "../state"
 
 export const useHotKeys = () => {
   const { importantNodeIds } = useEditorContext()
-  const nodes = useStore(NodesAtom)
 
   useEffect(() => {
     const hotKeysHandler = (e: KeyboardEvent) => {
       if ([KEY_CODE_BACK, KEY_CODE_DELETE].includes(e.key)) {
+        const nodes = NodesAtom.get()
+
         const selectedNodesIds = nodes
           .filter((node) => node.state === NodeState.selected)
           .filter((node) => importantNodeIds && !importantNodeIds.includes(node.id))
@@ -35,5 +35,5 @@ export const useHotKeys = () => {
     window.addEventListener("keydown", hotKeysHandler)
 
     return () => window.removeEventListener("keydown", hotKeysHandler)
-  }, [nodes])
+  }, [])
 }

--- a/packages/react-flow-editor/src/Editor/helpers/selectionZone.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/selectionZone.ts
@@ -1,9 +1,4 @@
-import { useStore } from "@nanostores/react"
-import { RefObject, useCallback } from "react"
-
 import { Node, RectZone, SelectionZone, Transformation } from "../../types"
-import { AutoScrollAtom, AutoScrollDirection, DragItemAtom, SelectionZoneAtom, TransformationMap } from "../state"
-import { getRectFromRef } from "./getRectFromRef"
 
 export const isNodeInSelectionZone = (node: Node, zone: SelectionZone | null, transform: Transformation): boolean => {
   if (zone === null) return false
@@ -32,49 +27,3 @@ export const cornersToRect = (zone: SelectionZone | null): RectZone =>
         right: 0,
         bottom: 0
       }
-
-export const useSelectionZone = (zoomContainerRef: RefObject<HTMLElement>) => {
-  const selectionZone = useStore(SelectionZoneAtom)
-  const transformation = useStore(TransformationMap)
-  const dragItem = useStore(DragItemAtom)
-  const autoScroll = useStore(AutoScrollAtom)
-
-  const initSelectionZone = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
-      if (e.shiftKey) {
-        const zoomContainerRect = getRectFromRef(zoomContainerRef)
-
-        const left = (e.clientX - zoomContainerRect.left) / transformation.zoom
-        const top = (e.clientY - zoomContainerRect.top) / transformation.zoom
-        const point = { x: left, y: top }
-
-        SelectionZoneAtom.set({ cornerStart: point, cornerEnd: point })
-      }
-    },
-    [transformation.zoom, zoomContainerRef]
-  )
-
-  const expandSelectionZone = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
-      if (selectionZone) {
-        const deltaX = (e.clientX - dragItem.x) / transformation.zoom
-        const deltaY = (e.clientY - dragItem.y) / transformation.zoom
-
-        SelectionZoneAtom.set({
-          ...selectionZone,
-          cornerEnd: {
-            x:
-              selectionZone.cornerEnd.x +
-              ([AutoScrollDirection.left, AutoScrollDirection.right].includes(autoScroll.direction!) ? 0 : deltaX),
-            y:
-              selectionZone.cornerEnd.y +
-              ([AutoScrollDirection.top, AutoScrollDirection.bottom].includes(autoScroll.direction!) ? 0 : deltaY)
-          }
-        })
-      }
-    },
-    [dragItem, transformation.zoom, selectionZone]
-  )
-
-  return { initSelectionZone, expandSelectionZone }
-}

--- a/packages/react-flow-editor/src/Editor/helpers/useEditorRectsMounted.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/useEditorRectsMounted.ts
@@ -1,6 +1,6 @@
-import { useContext, useEffect } from "react"
+import { useEffect } from "react"
 
-import { EditorContext } from "../context"
+import { useEditorContext } from "../editor-context"
 
 /**
  * @deprecated
@@ -13,7 +13,7 @@ export const useEditorRectsMounted = ({
   zoomContainerRef: React.RefObject<HTMLDivElement>
   editorContainerRef: React.RefObject<HTMLDivElement>
 }) => {
-  const { onEditorRectsMounted } = useContext(EditorContext)
+  const { onEditorRectsMounted } = useEditorContext()
 
   useEffect(() => {
     if (onEditorRectsMounted) {

--- a/packages/react-flow-editor/src/Editor/helpers/useSelectionZone.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/useSelectionZone.ts
@@ -1,0 +1,53 @@
+import { useStore } from "@nanostores/react"
+import { RefObject, useCallback } from "react"
+
+import { AutoScrollAtom, AutoScrollDirection, DragItemAtom, SelectionZoneAtom, TransformationMap } from "../state"
+import { getRectFromRef } from "./getRectFromRef"
+
+export const useSelectionZone = (zoomContainerRef: RefObject<HTMLElement>) => {
+  const selectionZone = useStore(SelectionZoneAtom)
+
+  const initSelectionZone = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      if (e.shiftKey) {
+        const transformation = TransformationMap.get()
+        const zoomContainerRect = getRectFromRef(zoomContainerRef)
+
+        const left = (e.clientX - zoomContainerRect.left) / transformation.zoom
+        const top = (e.clientY - zoomContainerRect.top) / transformation.zoom
+        const point = { x: left, y: top }
+
+        SelectionZoneAtom.set({ cornerStart: point, cornerEnd: point })
+      }
+    },
+    [zoomContainerRef]
+  )
+
+  const expandSelectionZone = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      if (selectionZone) {
+        const transformation = TransformationMap.get()
+        const dragItem = DragItemAtom.get()
+        const autoScroll = AutoScrollAtom.get()
+
+        const deltaX = (e.clientX - dragItem.x) / transformation.zoom
+        const deltaY = (e.clientY - dragItem.y) / transformation.zoom
+
+        SelectionZoneAtom.set({
+          ...selectionZone,
+          cornerEnd: {
+            x:
+              selectionZone.cornerEnd.x +
+              ([AutoScrollDirection.left, AutoScrollDirection.right].includes(autoScroll.direction!) ? 0 : deltaX),
+            y:
+              selectionZone.cornerEnd.y +
+              ([AutoScrollDirection.top, AutoScrollDirection.bottom].includes(autoScroll.direction!) ? 0 : deltaY)
+          }
+        })
+      }
+    },
+    [selectionZone]
+  )
+
+  return { initSelectionZone, expandSelectionZone }
+}

--- a/packages/react-flow-editor/src/Editor/helpers/useSelectionZone.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/useSelectionZone.ts
@@ -20,7 +20,7 @@ export const useSelectionZone = (zoomContainerRef: RefObject<HTMLElement>) => {
         SelectionZoneAtom.set({ cornerStart: point, cornerEnd: point })
       }
     },
-    [zoomContainerRef]
+    [selectionZone]
   )
 
   const expandSelectionZone = useCallback(

--- a/packages/react-flow-editor/src/Editor/rects-context.ts
+++ b/packages/react-flow-editor/src/Editor/rects-context.ts
@@ -1,6 +1,7 @@
-import { createContext } from "react"
+import { createContext, useContext } from "react"
 
 import { MountedContexts } from "./types"
 
-export const EditorContext = createContext<any>({} as any)
 export const RectsContext = createContext<MountedContexts>({} as MountedContexts)
+
+export const useRectsContext = () => useContext(RectsContext)

--- a/packages/react-flow-editor/src/Editor/state/NewConnection/actions/dragArrowDisconnector.ts
+++ b/packages/react-flow-editor/src/Editor/state/NewConnection/actions/dragArrowDisconnector.ts
@@ -1,0 +1,39 @@
+import { action } from "nanostores"
+
+import { DragItemType } from "@/Editor/types"
+import { NodeState, Output } from "@/types"
+
+import { DragItemAtom } from "../../DragItem"
+import { nodeActions, NodesAtom } from "../../Nodes"
+import { NewConnectionAtom } from "../store"
+import { TransformationMap } from "../../Transformation"
+import { SvgOffsetAtom } from "../../SvgOffset"
+
+export const dragArrowDisconnector = action(
+  NewConnectionAtom,
+  "dragArrowDisconnector",
+  (store, e: React.MouseEvent<SVGRectElement>, fromId: string, output: Output, zoomRect: DOMRect) => {
+    const transformation = TransformationMap.get()
+    const svgOffset = SvgOffsetAtom.get()
+    const fromNode = NodesAtom.get().find((node) => node.id === fromId)!
+
+    nodeActions.markDisabledNodes(fromNode)
+
+    DragItemAtom.set({
+      type: DragItemType.connection,
+      id: fromId,
+      output,
+      x: e.clientX,
+      y: e.clientY
+    })
+
+    const newPos = {
+      x: (e.clientX - zoomRect.left) / transformation.zoom - svgOffset.x,
+      y: (e.clientY - zoomRect.top) / transformation.zoom - svgOffset.y
+    }
+
+    store.set(newPos)
+
+    nodeActions.changeNodeState(fromId, NodeState.draggingConnector)
+  }
+)

--- a/packages/react-flow-editor/src/Editor/state/NewConnection/actions/dragNewConnectionHandler.ts
+++ b/packages/react-flow-editor/src/Editor/state/NewConnection/actions/dragNewConnectionHandler.ts
@@ -1,0 +1,23 @@
+import React from "react"
+import { action } from "nanostores"
+
+import { SvgOffsetAtom } from "@/Editor/state/SvgOffset"
+import { TransformationMap } from "@/Editor/state/Transformation"
+
+import { NewConnectionAtom } from "../store"
+
+export const dragNewConnectionHandler = action(
+  NewConnectionAtom,
+  "dragNewConnectionHandler",
+  (store, e: React.MouseEvent<HTMLElement>, zoomRect: DOMRect) => {
+    const transformation = TransformationMap.get()
+    const svgOffset = SvgOffsetAtom.get()
+
+    const newPos = {
+      x: (e.clientX - zoomRect.left) / transformation.zoom - svgOffset.x,
+      y: (e.clientY - zoomRect.top) / transformation.zoom - svgOffset.y
+    }
+
+    store.set(newPos)
+  }
+)

--- a/packages/react-flow-editor/src/Editor/state/NewConnection/actions/index.ts
+++ b/packages/react-flow-editor/src/Editor/state/NewConnection/actions/index.ts
@@ -1,0 +1,3 @@
+export { startNewConnection } from "./startNewConnection"
+export { dragNewConnectionHandler } from "./dragNewConnectionHandler"
+export { dragArrowDisconnector } from "./dragArrowDisconnector"

--- a/packages/react-flow-editor/src/Editor/state/NewConnection/actions/startNewConnection.ts
+++ b/packages/react-flow-editor/src/Editor/state/NewConnection/actions/startNewConnection.ts
@@ -1,0 +1,39 @@
+import { action } from "nanostores"
+
+import { NodeState, Output } from "@/types"
+import { DragItemType } from "@/Editor/types"
+import { nodeActions, NodesAtom } from "@/Editor/state/Nodes"
+import { SvgOffsetAtom } from "@/Editor/state/SvgOffset"
+import { TransformationMap } from "@/Editor/state/Transformation"
+import { DragItemAtom } from "@/Editor/state/DragItem"
+
+import { NewConnectionAtom } from "../store"
+
+export const startNewConnection = action(
+  NewConnectionAtom,
+  "startNewConnection",
+  (_, nodeId: string, zoomRect: DOMRect, e: React.MouseEvent<HTMLElement>, output: Output) => {
+    const svgOffset = SvgOffsetAtom.get()
+    const transformation = TransformationMap.get()
+    const node = NodesAtom.get().find((node) => node.id === nodeId)!
+
+    nodeActions.changeNodeState(node.id, NodeState.draggingConnector)
+
+    const pos = {
+      x: -svgOffset.x + (e.clientX - zoomRect.left) / transformation.zoom,
+      y: -svgOffset.y + (e.clientY - zoomRect.top) / transformation.zoom
+    }
+
+    NewConnectionAtom.set(pos)
+
+    DragItemAtom.set({
+      type: DragItemType.connection,
+      output,
+      id: node.id,
+      x: e.clientX,
+      y: e.clientY
+    })
+
+    nodeActions.markDisabledNodes(node)
+  }
+)

--- a/packages/react-flow-editor/src/Editor/state/NewConnection/index.ts
+++ b/packages/react-flow-editor/src/Editor/state/NewConnection/index.ts
@@ -1,1 +1,2 @@
 export * from "./store"
+export * as newConnectionActions from "./actions"

--- a/packages/react-flow-editor/src/Editor/state/Nodes/actions/base.ts
+++ b/packages/react-flow-editor/src/Editor/state/Nodes/actions/base.ts
@@ -2,7 +2,7 @@ import { action } from "nanostores"
 
 import { NodeState } from "@/types"
 
-import { NodesAtom } from "./store"
+import { NodesAtom } from "../store"
 
 export const changeNodeState = action(NodesAtom, "changeNodeState", (store, nodeId: string, state: NodeState) => {
   store.set(store.get().map((node) => (node.id === nodeId ? { ...node, state } : node)))

--- a/packages/react-flow-editor/src/Editor/state/Nodes/actions/dragNodeHandler.ts
+++ b/packages/react-flow-editor/src/Editor/state/Nodes/actions/dragNodeHandler.ts
@@ -1,0 +1,31 @@
+import { action } from "nanostores"
+
+import { NodeState } from "@/types"
+import { DragItemAtom } from "@/Editor/state/DragItem"
+import { TransformationMap } from "@/Editor/state/Transformation"
+
+import { NodesAtom } from "../store"
+
+export const dragNodeHandler = action(NodesAtom, "changeNodeState", (store, e: React.MouseEvent<HTMLElement>) => {
+  const dragItem = DragItemAtom.get()
+  const transformation = TransformationMap.get()
+
+  store.set(
+    store.get().map((el) => {
+      const isDragging = el.id === dragItem.id
+      const isShiftSelected = e.shiftKey && el.state === NodeState.selected
+
+      return isDragging || isShiftSelected
+        ? {
+            ...el,
+            position: {
+              x: el.position.x + (e.clientX - dragItem.x) / transformation.zoom,
+              y: el.position.y + (e.clientY - dragItem.y) / transformation.zoom
+            },
+            rectPosition: document.getElementById(el.id)?.getBoundingClientRect(),
+            state: isShiftSelected ? NodeState.selected : NodeState.dragging
+          }
+        : { ...el, state: null }
+    })
+  )
+})

--- a/packages/react-flow-editor/src/Editor/state/Nodes/actions/index.ts
+++ b/packages/react-flow-editor/src/Editor/state/Nodes/actions/index.ts
@@ -1,0 +1,4 @@
+export * from "./base"
+export { markDisabledNodes } from "./markDisabledNodes"
+export { dragNodeHandler } from "./dragNodeHandler"
+export { dragSelectionZoneHandler } from "./selectionZoneHandler"

--- a/packages/react-flow-editor/src/Editor/state/Nodes/actions/markDisabledNodes.ts
+++ b/packages/react-flow-editor/src/Editor/state/Nodes/actions/markDisabledNodes.ts
@@ -1,0 +1,22 @@
+import { action } from "nanostores"
+
+import { Node, NodeState } from "@/types"
+
+import { NodesAtom } from "../store"
+
+const isNoNodeFreeInputs = (node: Node, nodes: Node[]): boolean =>
+  nodes.filter((curNode) => curNode.outputs.map((out) => out.nextNodeId).includes(node.id)).length === node.inputNumber
+
+const notTheSameNode = (connectableNode: Node, curNode: Node): boolean => curNode.id !== connectableNode.id
+
+export const markDisabledNodes = action(NodesAtom, "changeNodeState", (store, connectableNode: Node) => {
+  const nodes = store.get()
+
+  const disabledNodesIds = nodes
+    .filter((curNode) => notTheSameNode(connectableNode, curNode) && isNoNodeFreeInputs(curNode, nodes))
+    .map((curNode) => curNode.id)
+
+  store.set(
+    store.get().map((node) => (disabledNodesIds.includes(node.id) ? { ...node, state: NodeState.disabled } : node))
+  )
+})

--- a/packages/react-flow-editor/src/Editor/state/Nodes/actions/selectionZoneHandler.ts
+++ b/packages/react-flow-editor/src/Editor/state/Nodes/actions/selectionZoneHandler.ts
@@ -1,0 +1,20 @@
+import { action } from "nanostores"
+
+import { NodeState } from "@/types"
+import { isNodeInSelectionZone } from "@/Editor/helpers/selectionZone"
+
+import { SelectionZoneAtom } from "../../SelectionZone"
+import { TransformationMap } from "../../Transformation"
+import { NodesAtom } from "../store"
+
+export const dragSelectionZoneHandler = action(NodesAtom, "changeNodeState", (store) => {
+  const selectionZone = SelectionZoneAtom.get()
+  const transformation = TransformationMap.get()
+
+  store.set(
+    store.get().map((el) => ({
+      ...el,
+      state: isNodeInSelectionZone(el, selectionZone, transformation) ? NodeState.selected : null
+    }))
+  )
+})

--- a/packages/react-flow-editor/src/Editor/state/Transformation/actions.ts
+++ b/packages/react-flow-editor/src/Editor/state/Transformation/actions.ts
@@ -1,0 +1,24 @@
+import { action } from "nanostores"
+
+import { DragItemAtom } from "../DragItem"
+import { TransformationMap } from "./store"
+
+export const dragViewportHandler = action(
+  TransformationMap,
+  "dragViewportHandler",
+  (store, e: React.MouseEvent<HTMLElement>) => {
+    const dragItem = DragItemAtom.get()
+    const transformation = store.get()
+
+    const newPos = {
+      x: (e.clientX - dragItem.x) / transformation.zoom,
+      y: (e.clientY - dragItem.y) / transformation.zoom
+    }
+
+    store.set({
+      ...transformation,
+      dx: transformation.dx + newPos.x,
+      dy: transformation.dy + newPos.y
+    })
+  }
+)

--- a/packages/react-flow-editor/src/Editor/state/Transformation/index.ts
+++ b/packages/react-flow-editor/src/Editor/state/Transformation/index.ts
@@ -1,1 +1,2 @@
 export * from "./store"
+export * as transformationActions from "./actions"

--- a/packages/react-flow-editor/src/Editor/types.ts
+++ b/packages/react-flow-editor/src/Editor/types.ts
@@ -20,6 +20,6 @@ export type NodeGroupsRect = {
 }
 
 export type MountedContexts = {
-  zoomContainerRef: React.RefObject<HTMLDivElement>
-  editorContainerRef: React.RefObject<HTMLDivElement>
+  zoomContainer: HTMLDivElement
+  editorContainer: HTMLDivElement
 }


### PR DESCRIPTION
### Что сделано:
- Поправил `StoreUpdater`, оказывается подписки не бесплатные :(
- поправил контексты, сделал отдельные хуки чтобы их получать
- теперь в RectContext передается сам DOM элемент, и он всегда будет, потому что `document.querySelector(".zoom-container")`
- Посмотрел где можно, не передавать полностью данные а частично, например в Output достаточно передавать `nodeId` и `nodeState`, остальные данные от ноды ему не нужны
- переписал большинство `useStore(Atom)` на `Atom.get()`, потому что верхнеуровневый вызов `useStore` заставляет компонент ререндерится каждый раз, когда значение изменилось, но оно не всегда нам нужно