### PR TITLE
Change mechanic of  DnD outputs

### DIFF
--- a/packages/e2e/cypress/integration/e2e/Connections/connections.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Connections/connections.cy.ts
@@ -66,7 +66,11 @@ context("Node connections", () => {
 
     it("Should drag connection via autoscroll", () => {
       connectionsModel.mouseDown(FIRST_NODE_CONNECTOR.X, FIRST_NODE_CONNECTOR.Y)
-      connectionsModel.getRoot().realMouseMove(CANVAS_ZONE_POINTS.RIGHT, CANVAS_ZONE_POINTS.TOP).wait(1000)
+      connectionsModel
+        .getRoot()
+        .realMouseMove(FIRST_NODE_CONNECTOR.X + 10, FIRST_NODE_CONNECTOR.Y)
+        .realMouseMove(CANVAS_ZONE_POINTS.RIGHT, CANVAS_ZONE_POINTS.TOP)
+        .wait(1000)
 
       cy.get(selectors.CONNECTION)
         .last()
@@ -83,7 +87,9 @@ context("Node connections", () => {
     it("Should disable node without empty inputs", () => {
       connectionsModel.getNodeElement(1).then(($el) => expect($el.hasClass(NodeState.disabled)).to.equal(false))
 
-      connectionsModel.mouseDown(SECOND_NODE_CONNECTOR.X, SECOND_NODE_CONNECTOR.Y)
+      connectionsModel
+        .mouseDown(SECOND_NODE_CONNECTOR.X, SECOND_NODE_CONNECTOR.Y)
+        .realMouseMove(SECOND_NODE_CONNECTOR.X + 1, SECOND_NODE_CONNECTOR.Y)
 
       connectionsModel.getNodeElement(1).then(($el) => expect($el.hasClass(NodeState.disabled)).to.equal(true))
     })

--- a/packages/react-flow-editor/src/Editor/components/Output/index.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Output/index.tsx
@@ -3,12 +3,12 @@ import React from "react"
 import { useStore } from "@nanostores/react"
 
 import { NodeState, Output as OutputType } from "@/types"
-import { DragItemAtom, HoveredNodeIdAtom, newConnectionActions } from "@/Editor/state"
-import { useRectsContext } from "@/Editor/rects-context"
+import { DragItemAtom, HoveredNodeIdAtom } from "@/Editor/state"
+import { DragItemType } from "@/Editor/types"
 
 import { BUTTON_LEFT } from "../../constants"
 import { useEditorContext } from "../../editor-context"
-import { findDOMRect, resetEvent } from "../../helpers"
+import { resetEvent } from "../../helpers"
 
 type Props = {
   nodeId: string
@@ -18,16 +18,18 @@ type Props = {
 
 export const Output: React.FC<Props> = React.memo(({ nodeId, nodeState, output }) => {
   const { OutputComponent } = useEditorContext()
-  const { zoomContainerRef } = useRectsContext()
   const hoveredNodeId = useStore(HoveredNodeIdAtom)
   const dragItem = useStore(DragItemAtom)
 
   const startNewConnection = (e: React.MouseEvent<HTMLElement>) => {
-    const zoomRect = findDOMRect(zoomContainerRef.current)
-
     resetEvent(e)
     if (e.button === BUTTON_LEFT) {
-      newConnectionActions.startNewConnection(nodeId, zoomRect, e, output)
+      DragItemAtom.set({
+        type: DragItemType.connectionPoint,
+        output: output,
+        id: nodeId,
+        ...output.position
+      })
     }
   }
 

--- a/packages/react-flow-editor/src/Editor/helpers/DnD/index.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/DnD/index.ts
@@ -38,7 +38,7 @@ export default ({
       checkAutoScrollEnable(e)
     }
 
-    DragItemAtom.set({ ...dragItem, x: e.clientX, y: e.clientY })
+    DragItemAtom.set({ ...DragItemAtom.get(), x: e.clientX, y: e.clientY })
   }
 
   const onDragEnded = () => {

--- a/packages/react-flow-editor/src/Editor/helpers/DnD/useDragTransformations.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/DnD/useDragTransformations.ts
@@ -26,6 +26,9 @@ export const useDragTransformations = ({
     [DragItemType.selectionZone]: (e: React.MouseEvent<HTMLElement>) => {
       expandSelectionZone(e)
       nodeActions.dragSelectionZoneHandler()
+    },
+    [DragItemType.connectionPoint]: (e: React.MouseEvent<HTMLElement>) => {
+      newConnectionActions.startNewConnection(e, zoomRect)
     }
   }
 }

--- a/packages/react-flow-editor/src/Editor/state/NewConnection/actions/startNewConnection.ts
+++ b/packages/react-flow-editor/src/Editor/state/NewConnection/actions/startNewConnection.ts
@@ -1,6 +1,6 @@
 import { action } from "nanostores"
 
-import { NodeState, Output } from "@/types"
+import { NodeState } from "@/types"
 import { DragItemType } from "@/Editor/types"
 import { nodeActions, NodesAtom } from "@/Editor/state/Nodes"
 import { SvgOffsetAtom } from "@/Editor/state/SvgOffset"
@@ -12,7 +12,9 @@ import { NewConnectionAtom } from "../store"
 export const startNewConnection = action(
   NewConnectionAtom,
   "startNewConnection",
-  (_, nodeId: string, zoomRect: DOMRect, e: React.MouseEvent<HTMLElement>, output: Output) => {
+  (_, e: React.MouseEvent<HTMLElement>, zoomRect: DOMRect) => {
+    const { output, id: nodeId } = DragItemAtom.get()
+
     const svgOffset = SvgOffsetAtom.get()
     const transformation = TransformationMap.get()
     const node = NodesAtom.get().find((node) => node.id === nodeId)!

--- a/packages/react-flow-editor/src/Editor/types.ts
+++ b/packages/react-flow-editor/src/Editor/types.ts
@@ -3,6 +3,7 @@ import { MutableRefObject } from "react"
 export enum DragItemType {
   node = "node",
   connection = "connection",
+  connectionPoint = "connectionPoint",
   viewPort = "viewPort",
   selectionZone = "selectionZone"
 }


### PR DESCRIPTION
- `connectionPoint` DragItemType was added when output was clicked but not dragged
-  logic of DnD of connections was moved to other DnD logic of editor
- dragging start (connector render) occurs after DnD (not click)