### PR TITLE
[2.2.5] Add prop to select connectors behaviour

### DIFF
--- a/packages/e2e/cypress/integration/e2e/Connections/Connections.model.ts
+++ b/packages/e2e/cypress/integration/e2e/Connections/Connections.model.ts
@@ -16,6 +16,9 @@ export class ConnectionsModel extends RootModel {
   getConnections() {
     return cy.get(selectors.CONNECTION)
   }
+  enableMiddleInflection() {
+    return cy.contains(selectors.MIDDLE_INFLECTION).click()
+  }
 }
 
 export const connectionsModel = new ConnectionsModel()

--- a/packages/e2e/cypress/integration/e2e/Connections/connections.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Connections/connections.cy.ts
@@ -21,8 +21,37 @@ context("Node connections", () => {
           coordinates.forEach((coord, inx) => expect(coord).to.closeTo(properCoordinates[inx], 2))
         })
 
+    const verifyFirstConnectionInitialMiddleInflection = () =>
+      connectionsModel
+        .getFirstConnectionPath()
+        .should("be.equal", "M 15310 15335 C 15210 15335, 15359 15140, 15259 15140")
+
     it("Should match default connector path", () => {
       verifyFirstConnectionInitial()
+    })
+
+    it("Should match middleInflection connector path", () => {
+      connectionsModel.enableMiddleInflection()
+      verifyFirstConnectionInitialMiddleInflection()
+    })
+
+    it("Should move connectors middleInflection", () => {
+      connectionsModel.enableMiddleInflection()
+      connectionsModel.mouseDown(FIRST_NODE_CONNECTOR.X, FIRST_NODE_CONNECTOR.Y)
+      connectionsModel.getRoot().realMouseMove(FIRST_NODE_CONNECTOR.X, FIRST_NODE_CONNECTOR.Y)
+
+      connectionsModel
+        .getLastConnectionPath()
+        .then(coordinatesFromPath)
+        .then((coordinates) => {
+          const properCoordinates = [15253, 15136, 15153, 15136, 15359, 15140, 15259, 15140]
+          coordinates.forEach((coord, inx) => expect(coord).to.closeTo(properCoordinates[inx], 2))
+        })
+
+      connectionsModel.getRoot().realMouseMove(CLICK_COORDS.SECOND_NODE.X, CLICK_COORDS.SECOND_NODE.Y)
+      connectionsModel.mouseUp(CLICK_COORDS.SECOND_NODE.X, CLICK_COORDS.SECOND_NODE.Y)
+
+      verifyFirstConnectionInitialMiddleInflection()
     })
 
     it("Should move connectors", () => {

--- a/packages/e2e/cypress/models/selectors.ts
+++ b/packages/e2e/cypress/models/selectors.ts
@@ -5,5 +5,6 @@ export default {
   ROOT: ".editor-root",
   DOT: ".dot",
   CONNECTION: ".connection",
-  NODE_ELEMENT: ".nodeElement"
+  NODE_ELEMENT: ".nodeElement",
+  MIDDLE_INFLECTION: "middleInflection"
 }

--- a/packages/examples/src/simple.scss
+++ b/packages/examples/src/simple.scss
@@ -190,8 +190,8 @@ body {
 
 .connectors-behaviour {
   position: fixed;
-  left: 400px;
-  top: 70px;
+  left: 215px;
+  bottom: 20px;
   border: 1px solid #ddd;
   border-radius: 6px;
   background: #fcfcfc;

--- a/packages/examples/src/simple.scss
+++ b/packages/examples/src/simple.scss
@@ -187,3 +187,23 @@ body {
   padding: 4px;
   border-radius: 4px;
 }
+
+.connectors-behaviour {
+  position: fixed;
+  left: 400px;
+  top: 70px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: #fcfcfc;
+  cursor: pointer;
+  display: flex;
+  z-index: 1;
+
+  & > div {
+    padding: 10px;
+
+    &.active {
+      background: #ddd;
+    }
+  }
+}

--- a/packages/examples/src/simple.tsx
+++ b/packages/examples/src/simple.tsx
@@ -6,14 +6,15 @@ import {
   Node,
   ScaleComponentProps,
   OutputComponentProps,
-  MenuComponentProps
+  MenuComponentProps,
+  ConnectorsBehaviour
 } from "@kseniass/react-flow-editor"
 import "./simple.scss"
 
 import { initialNodes, STYLED_CONFIG, TIPS } from "./constants"
 import { createNode } from "./helpers"
 import { NodeAttributes } from "./parts"
-import { NodesAtom } from "./store"
+import { ConnectorsBehaviourAtom, NodesAtom } from "./store"
 
 const NodeComponent = (node: Node) => <div className={`nodeElement ${node.state || ""}`}>Node</div>
 
@@ -43,8 +44,30 @@ const MenuComponent: React.FC<MenuComponentProps> = () => (
   </div>
 )
 
+const ConnectorsBehaviourComponent: React.FC = () => {
+  const connectorsBehaviour = useStore(ConnectorsBehaviourAtom)
+
+  return (
+    <div className="connectors-behaviour">
+      <div
+        onClick={() => ConnectorsBehaviourAtom.set(ConnectorsBehaviour.avoidSharpCorners)}
+        className={connectorsBehaviour === ConnectorsBehaviour.avoidSharpCorners ? "active" : ""}
+      >
+        {ConnectorsBehaviour.avoidSharpCorners}
+      </div>
+      <div
+        onClick={() => ConnectorsBehaviourAtom.set(ConnectorsBehaviour.middleInflection)}
+        className={connectorsBehaviour === ConnectorsBehaviour.middleInflection ? "active" : ""}
+      >
+        {ConnectorsBehaviour.middleInflection}
+      </div>
+    </div>
+  )
+}
+
 const App = () => {
   const nodes = useStore(NodesAtom)
+  const connectorsBehaviour = useStore(ConnectorsBehaviourAtom)
 
   return (
     <div className="editor-root">
@@ -52,6 +75,7 @@ const App = () => {
       <div className="flow-info">
         <NodeAttributes nodes={nodes} />
       </div>
+      <ConnectorsBehaviourComponent />
       <div className="react-editor-container">
         <Editor
           NodeComponent={NodeComponent}
@@ -63,6 +87,7 @@ const App = () => {
           onNodesChange={NodesAtom.set}
           importantNodeIds={[initialNodes[0].id]}
           connectorStyleConfig={STYLED_CONFIG}
+          connectorsBehaviour={connectorsBehaviour}
         />
       </div>
       <pre className="tips">{TIPS}</pre>

--- a/packages/examples/src/simple.tsx
+++ b/packages/examples/src/simple.tsx
@@ -49,18 +49,15 @@ const ConnectorsBehaviourComponent: React.FC = () => {
 
   return (
     <div className="connectors-behaviour">
-      <div
-        onClick={() => ConnectorsBehaviourAtom.set(ConnectorsBehaviour.avoidSharpCorners)}
-        className={connectorsBehaviour === ConnectorsBehaviour.avoidSharpCorners ? "active" : ""}
-      >
-        {ConnectorsBehaviour.avoidSharpCorners}
-      </div>
-      <div
-        onClick={() => ConnectorsBehaviourAtom.set(ConnectorsBehaviour.middleInflection)}
-        className={connectorsBehaviour === ConnectorsBehaviour.middleInflection ? "active" : ""}
-      >
-        {ConnectorsBehaviour.middleInflection}
-      </div>
+      {[ConnectorsBehaviour.avoidSharpCorners, ConnectorsBehaviour.middleInflection].map((type) => (
+        <div
+          key={type}
+          onClick={() => ConnectorsBehaviourAtom.set(type)}
+          className={connectorsBehaviour === type ? "active" : ""}
+        >
+          {type}
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/examples/src/simple.tsx
+++ b/packages/examples/src/simple.tsx
@@ -49,7 +49,7 @@ const ConnectorsBehaviourComponent: React.FC = () => {
 
   return (
     <div className="connectors-behaviour">
-      {[ConnectorsBehaviour.avoidSharpCorners, ConnectorsBehaviour.middleInflection].map((type) => (
+      {(["avoidSharpCorners", "middleInflection"] as Array<ConnectorsBehaviour>).map((type) => (
         <div
           key={type}
           onClick={() => ConnectorsBehaviourAtom.set(type)}

--- a/packages/examples/src/store.ts
+++ b/packages/examples/src/store.ts
@@ -5,4 +5,4 @@ import { initialNodes } from "./constants"
 
 export const NodesAtom = atom<Node[]>(initialNodes)
 
-export const ConnectorsBehaviourAtom = atom<ConnectorsBehaviour>(ConnectorsBehaviour.avoidSharpCorners)
+export const ConnectorsBehaviourAtom = atom<ConnectorsBehaviour>("avoidSharpCorners")

--- a/packages/examples/src/store.ts
+++ b/packages/examples/src/store.ts
@@ -1,6 +1,8 @@
 import { atom } from "nanostores"
-import { Node } from "@kseniass/react-flow-editor"
+import { ConnectorsBehaviour, Node } from "@kseniass/react-flow-editor"
 
 import { initialNodes } from "./constants"
 
 export const NodesAtom = atom<Node[]>(initialNodes)
+
+export const ConnectorsBehaviourAtom = atom<ConnectorsBehaviour>(ConnectorsBehaviour.avoidSharpCorners)

--- a/packages/react-flow-editor/package.json
+++ b/packages/react-flow-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kseniass/react-flow-editor",
-  "version": "2.1.5",
+  "version": "2.2.5",
   "description": "React component which enables creating flow editors with ease",
   "repository": {
     "type": "git",

--- a/packages/react-flow-editor/src/Editor/Editor.tsx
+++ b/packages/react-flow-editor/src/Editor/Editor.tsx
@@ -16,14 +16,16 @@ const Editor: React.FC<EditorProps> = ({
   SelectionZoneComponent,
   importantNodeIds,
   onNodesChange,
-  connectorStyleConfig
+  connectorStyleConfig,
+  connectorsBehaviour
 }) => (
   <EditorContext.Provider
     value={{
       NodeComponent,
       OutputComponent,
       importantNodeIds,
-      connectorStyleConfig
+      connectorStyleConfig,
+      connectorsBehaviour
     }}
   >
     <Canvas

--- a/packages/react-flow-editor/src/Editor/Editor.tsx
+++ b/packages/react-flow-editor/src/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { ConnectorsBehaviour, EditorProps } from "@/types"
+import { EditorProps } from "@/types"
 
 import { Canvas } from "./Canvas"
 import { EditorContext } from "./editor-context"
@@ -17,7 +17,7 @@ const Editor: React.FC<EditorProps> = ({
   importantNodeIds,
   onNodesChange,
   connectorStyleConfig,
-  connectorsBehaviour = ConnectorsBehaviour.avoidSharpCorners
+  connectorsBehaviour = "avoidSharpCorners"
 }) => (
   <EditorContext.Provider
     value={{

--- a/packages/react-flow-editor/src/Editor/Editor.tsx
+++ b/packages/react-flow-editor/src/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import type { EditorProps } from "@/types"
+import { ConnectorsBehaviour, EditorProps } from "@/types"
 
 import { Canvas } from "./Canvas"
 import { EditorContext } from "./editor-context"
@@ -17,7 +17,7 @@ const Editor: React.FC<EditorProps> = ({
   importantNodeIds,
   onNodesChange,
   connectorStyleConfig,
-  connectorsBehaviour
+  connectorsBehaviour = ConnectorsBehaviour.avoidSharpCorners
 }) => (
   <EditorContext.Provider
     value={{

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
@@ -1,7 +1,7 @@
 import { clamp, isEqual } from "lodash"
 import React from "react"
 
-import { Point } from "@/types"
+import { ConnectorsBehaviour, Point } from "@/types"
 import { DEFAULT_COLOR } from "@/Editor/constants"
 import { useEditorContext } from "@/Editor/editor-context"
 
@@ -32,7 +32,14 @@ const backwardHorizontalDy = (dist: number, yDist: number) =>
 const backwardDx = (dist: number) =>
   dist > X_FORWARD_OFFSET_THRESHOLD ? dist / X_FORWARD_OFFSET_DELIMITER : X_FORWARD_OFFSET_MINIMUM
 
-const defineDxDy = (inputPosition: Point, outputPosition: Point) => {
+const defineDxDy = (inputPosition: Point, outputPosition: Point, connectorsBehaviour: ConnectorsBehaviour) => {
+  if (connectorsBehaviour === ConnectorsBehaviour.middleInflection) {
+    return {
+      dx: Math.max(Math.abs(inputPosition.x - outputPosition.x) / 1.5, 100),
+      dy: 0
+    }
+  }
+
   const xDist = inputPosition.x - outputPosition.x
   const yDist = inputPosition.y - outputPosition.y
   const dist = Math.sqrt(xDist ** 2 + yDist ** 2)
@@ -45,9 +52,9 @@ const defineDxDy = (inputPosition: Point, outputPosition: Point) => {
 }
 
 const InputConnection: React.FC<InputConnectionProps> = ({ inputPosition, outputPosition }) => {
-  const { connectorStyleConfig } = useEditorContext()
+  const { connectorStyleConfig, connectorsBehaviour = ConnectorsBehaviour.avoidSharpCorners } = useEditorContext()
 
-  const { dx, dy } = defineDxDy(inputPosition, outputPosition)
+  const { dx, dy } = defineDxDy(inputPosition, outputPosition, connectorsBehaviour)
 
   const a1 = { x: inputPosition.x - dx, y: inputPosition.y + dy }
   const a2 = { x: outputPosition.x + dx, y: outputPosition.y + dy }

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
@@ -52,7 +52,7 @@ const defineDxDy = (inputPosition: Point, outputPosition: Point, connectorsBehav
 }
 
 const InputConnection: React.FC<InputConnectionProps> = ({ inputPosition, outputPosition }) => {
-  const { connectorStyleConfig, connectorsBehaviour = ConnectorsBehaviour.avoidSharpCorners } = useEditorContext()
+  const { connectorStyleConfig, connectorsBehaviour } = useEditorContext()
 
   const { dx, dy } = defineDxDy(inputPosition, outputPosition, connectorsBehaviour)
 

--- a/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Connections/components/InputConnection.tsx
@@ -33,7 +33,7 @@ const backwardDx = (dist: number) =>
   dist > X_FORWARD_OFFSET_THRESHOLD ? dist / X_FORWARD_OFFSET_DELIMITER : X_FORWARD_OFFSET_MINIMUM
 
 const defineDxDy = (inputPosition: Point, outputPosition: Point, connectorsBehaviour: ConnectorsBehaviour) => {
-  if (connectorsBehaviour === ConnectorsBehaviour.middleInflection) {
+  if (connectorsBehaviour === "middleInflection") {
     return {
       dx: Math.max(Math.abs(inputPosition.x - outputPosition.x) / 1.5, 100),
       dy: 0

--- a/packages/react-flow-editor/src/types.ts
+++ b/packages/react-flow-editor/src/types.ts
@@ -27,6 +27,11 @@ export enum NodeState {
   disabled = "disabled"
 }
 
+export enum ConnectorsBehaviour {
+  middleInflection = "middleInflection",
+  avoidSharpCorners = "avoidSharpCorners"
+}
+
 export type Output = {
   id: string
   position: Point
@@ -83,4 +88,5 @@ export type EditorProps = {
   OutputComponent?: React.FC<OutputComponentProps>
   importantNodeIds?: Array<string>
   connectorStyleConfig?: ConnectorStyleConfig
+  connectorsBehaviour?: ConnectorsBehaviour
 }

--- a/packages/react-flow-editor/src/types.ts
+++ b/packages/react-flow-editor/src/types.ts
@@ -27,10 +27,7 @@ export enum NodeState {
   disabled = "disabled"
 }
 
-export enum ConnectorsBehaviour {
-  middleInflection = "middleInflection",
-  avoidSharpCorners = "avoidSharpCorners"
-}
+export type ConnectorsBehaviour = "middleInflection" | "avoidSharpCorners"
 
 export type Output = {
   id: string


### PR DESCRIPTION
- `connectorsBehaviour` prop was added to allow select connectors behaviour
- Two options `middleInflection`, `avoidSharpCorners`
- `avoidSharpCorners` is a default value
- Tests were added
- Option selector was added to example