### PR TITLE
[3.2.5] Add node id to props

### DIFF
--- a/packages/react-flow-editor/package.json
+++ b/packages/react-flow-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kseniass/react-flow-editor",
-  "version": "2.2.5",
+  "version": "3.2.5",
   "description": "React component which enables creating flow editors with ease",
   "repository": {
     "type": "git",

--- a/packages/react-flow-editor/src/Editor/components/Node/node.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Node/node.tsx
@@ -36,7 +36,7 @@ const Node: React.FC<
       onMouseLeave={nodeInteractions.onMouseLeave}
     >
       {node.outputs.map((out) => (
-        <Output key={out.id} nodeId={node.id} nodeState={node.state} output={out} />
+        <Output key={out.id} nodeId={node.id} output={out} />
       ))}
       <NodeComponent {...node} />
     </div>

--- a/packages/react-flow-editor/src/Editor/components/Output/index.tsx
+++ b/packages/react-flow-editor/src/Editor/components/Output/index.tsx
@@ -2,7 +2,7 @@ import { isEqual } from "lodash"
 import React from "react"
 import { useStore } from "@nanostores/react"
 
-import { NodeState, Output as OutputType } from "@/types"
+import { Output as OutputType } from "@/types"
 import { DragItemAtom, HoveredNodeIdAtom } from "@/Editor/state"
 import { DragItemType } from "@/Editor/types"
 
@@ -12,11 +12,10 @@ import { resetEvent } from "../../helpers"
 
 type Props = {
   nodeId: string
-  nodeState: NodeState | null
   output: OutputType
 }
 
-export const Output: React.FC<Props> = React.memo(({ nodeId, nodeState, output }) => {
+export const Output: React.FC<Props> = React.memo(({ nodeId, output }) => {
   const { OutputComponent } = useEditorContext()
   const hoveredNodeId = useStore(HoveredNodeIdAtom)
   const dragItem = useStore(DragItemAtom)
@@ -47,7 +46,7 @@ export const Output: React.FC<Props> = React.memo(({ nodeId, nodeState, output }
         transform: "translate(-50%, -50%)"
       }}
     >
-      <OutputComponent isOutlined={hoveredNodeId === nodeId} isActive={isActive} nodeState={nodeState} />
+      <OutputComponent isOutlined={hoveredNodeId === nodeId} isActive={isActive} nodeId={nodeId} />
     </div>
   )
 }, isEqual)


### PR DESCRIPTION
- Output component will receive id of it's node instead of node state. It will provide more freedom to users