### PR TITLE
feature: invert scroll scaling

### DIFF
--- a/packages/e2e/cypress/integration/e2e/Canvas/canvas.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Canvas/canvas.cy.ts
@@ -66,37 +66,37 @@ context(CONTEXT, () => {
     it("Should zoom out properly once", () => {
       canvasModel.wheel(WheelDirection.bottom)
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.95, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 1.05, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom out properly multiple", () => {
       canvasModel.wheelDirection(Array(3).fill(WheelDirection.bottom))
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.86, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 1.15, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom out properly to low threshold", () => {
       canvasModel.wheelDirection(Array(ZOOM_OUT_COUNT).fill(WheelDirection.bottom))
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.2, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 3, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom in properly once", () => {
       canvasModel.wheel(WheelDirection.top)
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 1.05, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.95, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom in properly multiple", () => {
       canvasModel.wheelDirection(Array(3).fill(WheelDirection.top))
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 1.15, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.85, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom in properly to high threshold", () => {
       canvasModel.wheelDirection(Array(ZOOM_IN_COUNT).fill(WheelDirection.top))
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 3, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.2, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom properly bidirectionally", () => {
@@ -111,7 +111,7 @@ context(CONTEXT, () => {
         WheelDirection.top
       ])
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.9, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 1.1, ZOOM_PX_DEVIATION)
     })
 
     it("Should zoom with move properly", () => {
@@ -123,7 +123,7 @@ context(CONTEXT, () => {
       )
       canvasModel.wheel(WheelDirection.bottom)
 
-      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 0.95, ZOOM_PX_DEVIATION)
+      canvasModel.canvasPosition().then(zoomFromMatrix).should("be.closeTo", 1.05, ZOOM_PX_DEVIATION)
 
       matchEndPosition()
     })

--- a/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
@@ -66,7 +66,7 @@ context(CONTEXT, () => {
   describe("Movements with autoscroll", () => {
     const checkCornerAutoscroll = () =>
       nodesModel.nodePositionNumeric(1).then(([x, y]) => {
-        expect(Number(y)).to.be.lessThan(0)
+        expect(Number(y)).to.be.greaterThan(0)
         expect(Number(x)).to.be.greaterThan(800)
       })
 

--- a/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
@@ -108,12 +108,5 @@ context(CONTEXT, () => {
 
       checkCornerAutoscroll()
     })
-
-    it("Should autoscroll with zoom", () => {
-      nodesModel.wheelDirection(Array(ZOOM_IN_COUNT).fill(WheelDirection.top))
-      nodesModel.dndWithDelayUp(520, 295, CANVAS_ZONE_POINTS.RIGHT, CANVAS_ZONE_POINTS.TOP)
-
-      checkCornerAutoscroll()
-    })
   })
 })

--- a/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
@@ -66,7 +66,7 @@ context(CONTEXT, () => {
   describe("Movements with autoscroll", () => {
     const checkCornerAutoscroll = () =>
       nodesModel.nodePositionNumeric(1).then(([x, y]) => {
-        expect(Number(y)).to.be.lessThan(0)
+        expect(Number(y)).to.be.lessThan(150)
         expect(Number(x)).to.be.greaterThan(800)
       })
 

--- a/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
+++ b/packages/e2e/cypress/integration/e2e/Nodes/movements.cy.ts
@@ -66,7 +66,7 @@ context(CONTEXT, () => {
   describe("Movements with autoscroll", () => {
     const checkCornerAutoscroll = () =>
       nodesModel.nodePositionNumeric(1).then(([x, y]) => {
-        expect(Number(y)).to.be.greaterThan(0)
+        expect(Number(y)).to.be.lessThan(0)
         expect(Number(x)).to.be.greaterThan(800)
       })
 
@@ -110,7 +110,7 @@ context(CONTEXT, () => {
     })
 
     it("Should autoscroll with zoom", () => {
-      nodesModel.wheelDirection(Array(ZOOM_IN_COUNT).fill(WheelDirection.bottom))
+      nodesModel.wheelDirection(Array(ZOOM_IN_COUNT).fill(WheelDirection.top))
       nodesModel.dndWithDelayUp(520, 295, CANVAS_ZONE_POINTS.RIGHT, CANVAS_ZONE_POINTS.TOP)
 
       checkCornerAutoscroll()

--- a/packages/react-flow-editor/src/Editor/helpers/zoom.ts
+++ b/packages/react-flow-editor/src/Editor/helpers/zoom.ts
@@ -32,9 +32,11 @@ export const useZoom = ({
     (event) => {
       if (currentDragItem.type) return
 
-      const zoomFactor = Math.pow(ZOOM_STEP + 1, Math.sign(event.deltaY))
+      const isScrollUp = event.deltaY > 0
 
-      TransformationMap.setKey("zoom", clampZoom(transformation.zoom * zoomFactor))
+      const newZoom = clampZoom(isScrollUp ? transformation.zoom - ZOOM_STEP : transformation.zoom + ZOOM_STEP)
+
+      TransformationMap.setKey("zoom", newZoom)
     },
     [currentDragItem, transformation]
   )


### PR DESCRIPTION
Whats done:
- invert scroll scaling, because a lot of services scale down on scroll up and scale up on scroll down.